### PR TITLE
Added check to set correct library name on windows

### DIFF
--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -42,7 +42,10 @@ Library
                  vector>=0.9 && < 0.12,
                  primitive>=0.6 && < 0.7,
                  storable-complex==0.2.*
-  Extra-libraries: fftw3
+  if os(windows)
+    Extra-libraries: fftw3-3
+  else
+    Extra-libraries: fftw3
 
   Extensions: ForeignFunctionInterface, RecordWildCards, BangPatterns, FlexibleInstances,
                 ScopedTypeVariables


### PR DESCRIPTION
The windows dll for fftw3 is named fftw3-3. This PR adds a check to check for windows and permits unmodified building on windows (and presumably linux/others).

I have not tested it on linux so testing on linux before updating and uploading would be greatly appreciated.

Thanks,

Joe