### PR TITLE
version 0.1.4.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # vector-fftw changelog
 
+## 0.1.4.1
+
+* Adjust imports to support newer GHCs.
+
 ## 0.1.4.0
 
 * Introduce multi-dimensional transforms:

--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -2,7 +2,7 @@ cabal-version:       >=1.10
 
 Name:                vector-fftw
 
-Version:             0.1.4.0
+Version:             0.1.4.1
 License:             BSD3
 License-file:        LICENSE
 Author:              Judah Jacobson


### PR DESCRIPTION
The changes from the commit b203402d3b210216ed9703c25a96f9c2632a0974 never made it into a Hackage release; there have only been metadata updates since (and unfortunately more than that was required to get this working with newer GHCs).